### PR TITLE
[010]Add,Fix:Icon,Card-style

### DIFF
--- a/frontend/__tests__/dashboard.page.test.tsx
+++ b/frontend/__tests__/dashboard.page.test.tsx
@@ -14,11 +14,11 @@ jest.mock("@/store/auth", () => ({
   ),
 }));
 
-describe("MePage (ユーザー情報画面)", () => {
+describe("DashboardPage (ダッシュボード画面)", () => {
   it("タイトル・ユーザー名・メールアドレス・ログアウトボタンが表示される", () => {
     render(<MePage />);
     expect(
-      screen.getByText((t) => t.includes("ユーザー情報"))
+      screen.getByRole("heading", { name: /ダッシュボード/ })
     ).toBeInTheDocument();
     expect(
       screen.getByText((t) => t.includes("テストユーザー"))

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from "react";
 import Header from "@/components/Header";
 import { useAuthStore } from "@/store/auth";
 import { useRouter } from "next/navigation";
+import { FaThLarge } from "react-icons/fa";
 
 export default function MePage() {
   const user = useAuthStore((s) => s.user);
@@ -30,8 +31,13 @@ export default function MePage() {
   return (
     <>
       <Header />
-      <div className="max-w-md mx-auto mt-20 p-6 bg-white rounded shadow">
-        <h1 className="text-2xl font-bold mb-4">ユーザー情報</h1>
+      <div className="max-w-xl mx-auto mt-10 p-6 bg-white rounded-2xl shadow-2xl border border-sky-100 sm:p-10">
+        <div className="flex items-center gap-2 mb-6">
+          <FaThLarge className="text-2xl text-blue-500" />
+          <h1 className="text-2xl font-bold tracking-wide text-blue-900">
+            ダッシュボード
+          </h1>
+        </div>
         {loading && <div>読み込み中...</div>}
         {error && <div className="text-red-500 text-sm">{error}</div>}
         {user && (

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import Header from "@/components/Header";
 import { useAuthStore } from "@/store/auth";
 import { useRouter } from "next/navigation";
-import { FaEye, FaEyeSlash } from "react-icons/fa";
+import { FaEye, FaEyeSlash, FaSignInAlt } from "react-icons/fa";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -44,8 +44,13 @@ export default function LoginPage() {
   return (
     <>
       <Header />
-      <div className="max-w-md mx-auto mt-20 p-6 bg-white rounded shadow">
-        <h1 className="text-2xl font-bold mb-4">ログイン</h1>
+      <div className="max-w-xl mx-auto mt-10 p-6 bg-white rounded-2xl shadow-2xl border border-sky-100 sm:p-10">
+        <div className="flex items-center gap-2 mb-6">
+          <FaSignInAlt className="text-2xl text-blue-500" />
+          <h1 className="text-2xl font-bold tracking-wide text-blue-900">
+            ログイン
+          </h1>
+        </div>
         <form onSubmit={handleSubmit} className="space-y-6">
           <div>
             <label

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import Header from "@/components/Header";
 import { useAuthStore } from "@/store/auth";
 import { useRouter } from "next/navigation";
-import { FaEye, FaEyeSlash } from "react-icons/fa";
+import { FaEye, FaEyeSlash, FaUserPlus } from "react-icons/fa";
 
 export default function RegisterPage() {
   const [name, setName] = useState("");
@@ -47,8 +47,13 @@ export default function RegisterPage() {
   return (
     <>
       <Header />
-      <div className="max-w-md mx-auto mt-20 p-6 bg-white rounded shadow">
-        <h1 className="text-2xl font-bold mb-4">新規登録</h1>
+      <div className="max-w-xl mx-auto mt-10 p-6 bg-white rounded-2xl shadow-2xl border border-sky-100 sm:p-10">
+        <div className="flex items-center gap-2 mb-6">
+          <FaUserPlus className="text-2xl text-blue-500" />
+          <h1 className="text-2xl font-bold tracking-wide text-blue-900">
+            新規登録
+          </h1>
+        </div>
         <form onSubmit={handleSubmit} className="space-y-6">
           <div>
             <label


### PR DESCRIPTION
画面毎にタイトルの横にアイコンを追加

dashboard画面のタイトルを「ユーザー情報」から「ダッシュボード」に修正
dashboard画面タイトル変更に伴いテストを変更
dashboard, login, register画面のカードスタイルをtravel-planに統一