### PR TITLE
[016]Fix:DB-column

### DIFF
--- a/backend/database/migrations/2024_05_25_000008_create_usage_histories_table.php
+++ b/backend/database/migrations/2024_05_25_000008_create_usage_histories_table.php
@@ -12,7 +12,6 @@ return new class extends Migration
             $table->bigIncrements('id');
             $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
             $table->integer('feature_id')->comment('1: travel_plans_ai, 2: visited_countries_ai');
-            $table->timestamp('used_at');
             $table->timestamps();
         });
     }

--- a/backend/database/seeders/AdminsTableSeeder.php
+++ b/backend/database/seeders/AdminsTableSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+use App\Models\Admin;
+
+class AdminsTableSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Admin::create([
+            'name' => env('ADMIN_NAME', 'administrator'),
+            'email' => env('ADMIN_EMAIL', 'administrator@sample.com'),
+            'password' => Hash::make(env('ADMIN_PASSWORD', 'administrator')),
+        ]);
+    }
+} 

--- a/backend/database/seeders/UsersTableSeeder.php
+++ b/backend/database/seeders/UsersTableSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+use App\Models\User;
+
+class UsersTableSeeder extends Seeder
+{
+    public function run(): void
+    {
+        User::create([
+            'name' => 'kakikukeko',
+            'email' => 'kakikukeko@sample.com',
+            'password' => Hash::make('kakikukeko'),
+        ]);
+    }
+} 

--- a/docs/DB設計.md
+++ b/docs/DB設計.md
@@ -104,11 +104,10 @@
 | id                      | bigIncrements | 主キー                      |
 | user_id                 | foreignId     | users テーブル参照          |
 | feature_id              | integer       | 機能 ID（下記対応表を参照） |
-| used_at                 | timestamp     | 利用日時                    |
 | created_at / updated_at | timestamps    | 作成 / 更新日時             |
 
 - 機能利用時にレコードを追加
-- 「本日分の利用回数」を `SELECT COUNT(*) FROM usage_histories WHERE user_id = ? AND feature_id = ? AND used_at >= 今日の0時` で取得
+- 「本日分の利用回数」を `SELECT COUNT(*) FROM usage_histories WHERE user_id = ? AND feature_id = ? AND created_at >= 今日の0時` で取得
 - 制限回数を超えていれば API でエラー返却
 - 履歴が残るため、将来的な分析や柔軟な制限（週・月単位など）にも対応可能
 


### PR DESCRIPTION
usage_historiesのused_atカラムを削除（created_atで同様の内容を確認可能のため）
管理者アカウントの初期Seederを作成
ユーザーアカウントの初期テストSeederを作成