### PR TITLE
[017]Add:usage-limits-for-travel-plan-generative-API

### DIFF
--- a/backend/app/Models/Admin.php
+++ b/backend/app/Models/Admin.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+class Admin extends Authenticatable
+{
+    use HasFactory, Notifiable;
+
+    protected $table = 'admins';
+
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+        'password' => 'hashed',
+    ];
+} 

--- a/backend/app/Models/TravelPlan.php
+++ b/backend/app/Models/TravelPlan.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TravelPlan extends Model
+{
+    protected $table = 'travel_plans';
+    protected $fillable = [
+        'user_id',
+        'country_id',
+        'start_date',
+        'end_date',
+        'budget',
+        'must_go_places',
+        'plan_json',
+    ];
+    protected $casts = [
+        'must_go_places' => 'array',
+        'plan_json' => 'array',
+    ];
+} 

--- a/backend/app/Models/UsageHistory.php
+++ b/backend/app/Models/UsageHistory.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UsageHistory extends Model
+{
+    protected $table = 'usage_histories';
+    protected $fillable = [
+        'user_id', 'feature_id',
+    ];
+} 

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -18,5 +18,16 @@ class DatabaseSeeder extends Seeder
         //     'name' => 'Test User',
         //     'email' => 'test@example.com',
         // ]);
+
+        // 必要なSeederをここで呼び出す
+        $this->call([
+            CountriesTableSeeder::class,
+            AdminsTableSeeder::class,
+            # Seederでは、トークンが発行されず、エラーが起こるためコメントアウト
+            # UsersTableSeeder::class,
+            # UsageHistoriesTableSeederは、ユーザーが作成されている必要があるのて登録後に個別で実行
+            # UsageHistoriesTableSeeder::class,
+            // 他にも必要なSeederがあればここに追加
+        ]);
     }
 }

--- a/backend/database/seeders/UsageHistoriesTableSeeder.php
+++ b/backend/database/seeders/UsageHistoriesTableSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\UsageHistory;
+use Carbon\Carbon;
+
+class UsageHistoriesTableSeeder extends Seeder
+{
+    public function run(): void
+    {
+        // 例: user_id=1, feature_id=1 の履歴を4件作成
+        for ($i = 0; $i < 4; $i++) {
+            UsageHistory::create([
+                'user_id' => 1,
+                'feature_id' => 1,
+                'created_at' => Carbon::now()->subHours($i),
+                'updated_at' => Carbon::now()->subHours($i),
+            ]);
+        }
+    }
+} 

--- a/backend/tests/Feature/TravelPlanAiTest.php
+++ b/backend/tests/Feature/TravelPlanAiTest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use App\Models\User;
 use Illuminate\Support\Facades\Http;
+use App\Models\Country;
 
 class TravelPlanAiTest extends TestCase
 {
@@ -34,6 +35,13 @@ class TravelPlanAiTest extends TestCase
         $token = $user->createToken('api-token')->plainTextToken;
         $this->fakeGeminiApi();
 
+        // Countryデータを作成
+        Country::create([
+            'name_ja' => '日本',
+            'name_en' => 'Japan',
+            'code' => 'JP',
+        ]);
+
         $payload = [
             'country' => '日本',
             'start_date' => '2024-07-01',
@@ -54,6 +62,13 @@ class TravelPlanAiTest extends TestCase
         $user = User::factory()->create();
         $token = $user->createToken('api-token')->plainTextToken;
         $this->fakeGeminiApi();
+
+        // Countryデータを作成
+        Country::create([
+            'name_ja' => '日本',
+            'name_en' => 'Japan',
+            'code' => 'JP',
+        ]);
 
         $payload = [
             'country' => '日本',
@@ -76,6 +91,13 @@ class TravelPlanAiTest extends TestCase
         $token = $user->createToken('api-token')->plainTextToken;
         $this->fakeGeminiApi();
 
+        // Countryデータを作成
+        Country::create([
+            'name_ja' => '日本',
+            'name_en' => 'Japan',
+            'code' => 'JP',
+        ]);
+
         $payload = [
             // countryがない
             'start_date' => '2024-07-01',
@@ -92,6 +114,12 @@ class TravelPlanAiTest extends TestCase
     public function test_generate_plan_unauthenticated()
     {
         $this->fakeGeminiApi();
+        // Countryデータを作成
+        Country::create([
+            'name_ja' => '日本',
+            'name_en' => 'Japan',
+            'code' => 'JP',
+        ]);
         $payload = [
             'country' => '日本',
             'start_date' => '2024-07-01',
@@ -100,5 +128,72 @@ class TravelPlanAiTest extends TestCase
         ];
         $response = $this->postJson('/api/v1/travel-plans/generate', $payload);
         $response->assertStatus(401);
+    }
+
+    public function test_generate_plan_limit_exceeded()
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('api-token')->plainTextToken;
+        $this->fakeGeminiApi();
+        Country::create([
+            'name_ja' => '日本',
+            'name_en' => 'Japan',
+            'code' => 'JP',
+        ]);
+        $payload = [
+            'country' => '日本',
+            'start_date' => '2024-07-01',
+            'end_date' => '2024-07-05',
+            'budget' => 100000,
+        ];
+        for ($i = 0; $i < 5; $i++) {
+            $this->withHeader('Authorization', 'Bearer ' . $token)
+                ->postJson('/api/v1/travel-plans/generate', $payload)
+                ->assertStatus(200);
+        }
+        $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/travel-plans/generate', $payload)
+            ->assertStatus(429)
+            ->assertJsonFragment(['error' => '本日のプラン生成回数上限（5回）に達しました。']);
+    }
+
+    public function test_generate_plan_gemini_api_failure()
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('api-token')->plainTextToken;
+        Http::fake(['*' => Http::response([], 500)]);
+        Country::create([
+            'name_ja' => '日本',
+            'name_en' => 'Japan',
+            'code' => 'JP',
+        ]);
+        $payload = [
+            'country' => '日本',
+            'start_date' => '2024-07-01',
+            'end_date' => '2024-07-05',
+            'budget' => 100000,
+        ];
+        $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/travel-plans/generate', $payload)
+            ->assertStatus(500)
+            ->assertJsonFragment(['error' => 'AI生成に失敗しました']);
+    }
+
+    public function test_generate_plan_country_not_found()
+    {
+        $user = User::factory()->create();
+        $token = $user->createToken('api-token')->plainTextToken;
+        $this->fakeGeminiApi();
+        // Countryデータを作成しない
+        $payload = [
+            'country' => '日本',
+            'start_date' => '2024-07-01',
+            'end_date' => '2024-07-05',
+            'budget' => 100000,
+        ];
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/v1/travel-plans/generate', $payload);
+        $response->assertStatus(500);
+        // 今後は「国が見つからない」旨のエラー返却に改善しても良い
     }
 } 

--- a/frontend/src/app/travel-plan/page.tsx
+++ b/frontend/src/app/travel-plan/page.tsx
@@ -24,6 +24,7 @@ export default function TravelPlanPage() {
   const [countries, setCountries] = useState<
     { id: number; name_ja: string; name_en: string; code: string }[]
   >([]);
+  const [error, setError] = useState<string | null>(null);
 
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const isAuthLoading = useAuthStore((s) => s.isAuthLoading);
@@ -66,6 +67,7 @@ export default function TravelPlanPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
+    setError(null);
     try {
       const res = await generateTravelPlan({
         country,
@@ -75,8 +77,14 @@ export default function TravelPlanPage() {
         must_go_places: places.length > 0 ? places : undefined,
       });
       setResult({ plan: res.data.plan });
-    } catch (err) {
+    } catch (err: any) {
       // エラーハンドリング
+      let msg = "予期せぬエラーが発生しました";
+      if (err?.response?.data?.error) {
+        msg = err.response.data.error;
+      }
+      setError(msg);
+      setResult(null);
     } finally {
       setLoading(false);
     }
@@ -261,7 +269,15 @@ export default function TravelPlanPage() {
           </button>
         </form>
         <div className="mt-10">
-          {result && (
+          {error && (
+            <div className="p-8 bg-gradient-to-br from-red-100 to-red-200 rounded-3xl shadow-xl border border-red-300">
+              <h2 className="font-bold mb-4 text-red-700 text-xl flex items-center gap-2">
+                <FaInfoCircle className="text-red-400" /> エラー
+              </h2>
+              <div className="text-red-700 text-lg font-semibold">{error}</div>
+            </div>
+          )}
+          {result && !error && (
             <div className="p-8 bg-gradient-to-br from-sky-50 to-blue-100 rounded-3xl shadow-xl border border-sky-200">
               <h2 className="font-bold mb-4 text-blue-700 text-xl flex items-center gap-2">
                 <FaMapMarkedAlt className="text-blue-400" /> 生成結果
@@ -269,13 +285,25 @@ export default function TravelPlanPage() {
               <div className="prose prose-blue max-w-none">
                 <ReactMarkdown
                   components={{
-                    h2: ({ node, ...props }) => (
+                    h2: ({
+                      node,
+                      ...props
+                    }: {
+                      node: any;
+                      [key: string]: any;
+                    }) => (
                       <h2 className="flex items-center gap-2 text-lg text-blue-700 mt-8 mb-2">
                         <FaInfoCircle className="text-blue-400" />
                         {props.children}
                       </h2>
                     ),
-                    h3: ({ node, ...props }) => (
+                    h3: ({
+                      node,
+                      ...props
+                    }: {
+                      node: any;
+                      [key: string]: any;
+                    }) => (
                       <h3 className="flex items-center gap-2 text-base text-blue-600 mt-6 mb-1">
                         <FaCalendarAlt className="text-blue-300" />
                         {props.children}


### PR DESCRIPTION
モデルの追加（Admin, TravelPlan, UsageHistory）
一括でSeederを実行可能に修正
旅行プラン作成で利用する生成AIの利用制限を追加