### PR TITLE
[038]Fix_Password_reset_func_Frontend_test_errors_Build_errors

### DIFF
--- a/backend/app/Http/Requests/RegisterRequest.php
+++ b/backend/app/Http/Requests/RegisterRequest.php
@@ -26,7 +26,14 @@ class RegisterRequest extends FormRequest
         return [
             'name' => 'required|string|max:255',
             'email' => 'required|string|email|max:255|unique:users',
-            'password' => 'required|string|min:8|confirmed',
+            'password' => [
+                'required',
+                'string',
+                'min:8',
+                'max:20',
+                'confirmed',
+                'regex:/^(?=.*[a-zA-Z])(?=.*\d).+$/'
+            ],
         ];
     }
 
@@ -49,6 +56,8 @@ class RegisterRequest extends FormRequest
             'password.required' => 'パスワードは必須です。',
             'password.string' => 'パスワードは文字列で入力してください。',
             'password.min' => 'パスワードは8文字以上で入力してください。',
+            'password.max' => 'パスワードは20文字以内で入力してください。',
+            'password.regex' => 'パスワードは英字と数字の両方を含む必要があります。',
             'password.confirmed' => 'パスワード確認が一致しません。',
         ];
     }

--- a/backend/app/Http/Requests/ResetPasswordRequest.php
+++ b/backend/app/Http/Requests/ResetPasswordRequest.php
@@ -24,7 +24,14 @@ class ResetPasswordRequest extends FormRequest
         return [
             'token' => ['required', 'string'],
             'email' => ['required', 'email'],
-            'password' => ['required', 'string', 'min:8', 'confirmed'],
+            'password' => [
+                'required',
+                'string',
+                'min:8',
+                'max:20',
+                'confirmed',
+                'regex:/^(?=.*[a-zA-Z])(?=.*\d).+$/'
+            ],
         ];
     }
 
@@ -41,6 +48,8 @@ class ResetPasswordRequest extends FormRequest
             'email.email' => '有効なメールアドレスを入力してください。',
             'password.required' => 'パスワードは必須です。',
             'password.min' => 'パスワードは8文字以上で入力してください。',
+            'password.max' => 'パスワードは20文字以内で入力してください。',
+            'password.regex' => 'パスワードは英字と数字の両方を含む必要があります。',
             'password.confirmed' => 'パスワードが一致しません。',
         ];
     }

--- a/backend/tests/Feature/AuthTest.php
+++ b/backend/tests/Feature/AuthTest.php
@@ -111,7 +111,7 @@ class AuthTest extends TestCase
         for ($i = 0; $i < 5; $i++) {
             $response = $this->postJson('/api/v1/login', [
                 'email' => 'test@example.com',
-                'password' => 'wrongpassword',
+                'password' => 'WrongPass456',
             ]);
             $response->assertStatus(401);
         }
@@ -146,7 +146,7 @@ class AuthTest extends TestCase
         for ($i = 0; $i < 4; $i++) {
             $response = $this->postJson('/api/v1/login', [
                 'email' => 'test@example.com',
-                'password' => 'wrongpassword',
+                'password' => 'WrongPass456',
             ]);
             $response->assertStatus(401);
         }

--- a/backend/tests/Feature/PasswordResetTest.php
+++ b/backend/tests/Feature/PasswordResetTest.php
@@ -73,8 +73,8 @@ class PasswordResetTest extends TestCase
         $response = $this->postJson('/api/v1/reset-password', [
             'token' => $token,
             'email' => 'test@example.com',
-            'password' => 'newpassword123',
-            'password_confirmation' => 'newpassword123',
+            'password' => 'NewPass123',  // 英字と数字を含む
+            'password_confirmation' => 'NewPass123',
         ]);
 
         $response->assertStatus(200)
@@ -83,7 +83,7 @@ class PasswordResetTest extends TestCase
             ]);
 
         $user->refresh();
-        $this->assertTrue(Hash::check('newpassword123', $user->password));
+        $this->assertTrue(Hash::check('NewPass123', $user->password));
     }
 
     public function test_reset_password_with_invalid_token()
@@ -95,8 +95,8 @@ class PasswordResetTest extends TestCase
         $response = $this->postJson('/api/v1/reset-password', [
             'token' => 'invalid-token',
             'email' => 'test@example.com',
-            'password' => 'newpassword123',
-            'password_confirmation' => 'newpassword123',
+            'password' => 'NewPass123',  // 英字と数字を含む
+            'password_confirmation' => 'NewPass123',
         ]);
 
         $response->assertStatus(400)
@@ -116,12 +116,17 @@ class PasswordResetTest extends TestCase
         $response = $this->postJson('/api/v1/reset-password', [
             'token' => $token,
             'email' => 'test@example.com',
-            'password' => 'newpassword123',
-            'password_confirmation' => 'differentpassword',
+            'password' => 'NewPass123',  // 英字と数字を含む
+            'password_confirmation' => 'DifferentPass123',
         ]);
 
         $response->assertStatus(422)
-            ->assertJsonValidationErrors(['password']);
+            ->assertJsonValidationErrors(['password'])
+            ->assertJson([
+                'errors' => [
+                    'password' => ['パスワードが一致しません。']
+                ]
+            ]);
     }
 
     public function test_reset_password_with_short_password()
@@ -135,11 +140,88 @@ class PasswordResetTest extends TestCase
         $response = $this->postJson('/api/v1/reset-password', [
             'token' => $token,
             'email' => 'test@example.com',
-            'password' => 'short',
-            'password_confirmation' => 'short',
+            'password' => 'Pass1',  // 5文字
+            'password_confirmation' => 'Pass1',
         ]);
 
         $response->assertStatus(422)
-            ->assertJsonValidationErrors(['password']);
+            ->assertJsonValidationErrors(['password'])
+            ->assertJson([
+                'errors' => [
+                    'password' => ['パスワードは8文字以上で入力してください。']
+                ]
+            ]);
+    }
+
+    public function test_reset_password_with_long_password()
+    {
+        $user = User::factory()->create([
+            'email' => 'test@example.com',
+        ]);
+
+        $token = Password::createToken($user);
+
+        $response = $this->postJson('/api/v1/reset-password', [
+            'token' => $token,
+            'email' => 'test@example.com',
+            'password' => 'Password123456789012345',  // 21文字
+            'password_confirmation' => 'Password123456789012345',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['password'])
+            ->assertJson([
+                'errors' => [
+                    'password' => ['パスワードは20文字以内で入力してください。']
+                ]
+            ]);
+    }
+
+    public function test_reset_password_without_letter()
+    {
+        $user = User::factory()->create([
+            'email' => 'test@example.com',
+        ]);
+
+        $token = Password::createToken($user);
+
+        $response = $this->postJson('/api/v1/reset-password', [
+            'token' => $token,
+            'email' => 'test@example.com',
+            'password' => '12345678',  // 数字のみ
+            'password_confirmation' => '12345678',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['password'])
+            ->assertJson([
+                'errors' => [
+                    'password' => ['パスワードは英字と数字の両方を含む必要があります。']
+                ]
+            ]);
+    }
+
+    public function test_reset_password_without_number()
+    {
+        $user = User::factory()->create([
+            'email' => 'test@example.com',
+        ]);
+
+        $token = Password::createToken($user);
+
+        $response = $this->postJson('/api/v1/reset-password', [
+            'token' => $token,
+            'email' => 'test@example.com',
+            'password' => 'Password',  // 英字のみ
+            'password_confirmation' => 'Password',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['password'])
+            ->assertJson([
+                'errors' => [
+                    'password' => ['パスワードは英字と数字の両方を含む必要があります。']
+                ]
+            ]);
     }
 }

--- a/frontend/__tests__/diary.page.test.tsx
+++ b/frontend/__tests__/diary.page.test.tsx
@@ -126,11 +126,20 @@ describe("DiaryPage (旅の日記画面)", () => {
       ).toBeInTheDocument();
     });
 
-    expect(
-      screen.getByText(
-        "地図をクリックすると、ピンが表示され下に日記作成フォームが表示されます"
-      )
-    ).toBeInTheDocument();
+    // 「日記を登録」タブに切り替える（アイコン付きのボタンを選択）
+    const createTabButtons = screen.getAllByRole("button", { name: /日記を登録/ });
+    const createTabButton = createTabButtons.find(button => button.querySelector('svg'));
+    await act(async () => {
+      fireEvent.click(createTabButton!);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "地図をクリックすると、ピンが表示され下に日記作成フォームが表示されます"
+        )
+      ).toBeInTheDocument();
+    });
 
     expect(screen.getByTestId("mock-diary-map")).toBeInTheDocument();
     expect(screen.getByTestId("mock-header")).toBeInTheDocument();
@@ -141,8 +150,15 @@ describe("DiaryPage (旅の日記画面)", () => {
       render(<DiaryPage />);
     });
 
+    // 「日記を登録」タブに切り替える（アイコン付きのボタンを選択）
+    const createTabButtons = screen.getAllByRole("button", { name: /日記を登録/ });
+    const createTabButton = createTabButtons.find(button => button.querySelector('svg'));
+    await act(async () => {
+      fireEvent.click(createTabButton!);
+    });
+
     // 初期状態では日記作成フォームは表示されない
-    expect(screen.queryByText("新しい日記を作成")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/タイトル/)).not.toBeInTheDocument();
 
     // 地図をクリック（モック）
     const mapClickButton = screen.getByTestId("mock-map-click");
@@ -151,11 +167,10 @@ describe("DiaryPage (旅の日記画面)", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("新しい日記を作成")).toBeInTheDocument();
+      // フォーム要素が表示される
+      expect(screen.getByLabelText(/タイトル/)).toBeInTheDocument();
     });
 
-    // フォーム要素が表示される
-    expect(screen.getByLabelText(/タイトル/)).toBeInTheDocument();
     expect(screen.getByLabelText(/訪問日時/)).toBeInTheDocument();
     expect(screen.getByLabelText(/内容/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "保存" })).toBeInTheDocument();
@@ -348,6 +363,13 @@ describe("DiaryPage (旅の日記画面)", () => {
         render(<DiaryPage />);
       });
 
+      // 「日記を登録」タブに切り替える（アイコン付きのボタンを選択）
+      const createTabButtons = screen.getAllByRole("button", { name: /日記を登録/ });
+      const createTabButton = createTabButtons.find(button => button.querySelector('svg'));
+      await act(async () => {
+        fireEvent.click(createTabButton!);
+      });
+
       // 地図をクリックしてフォームを表示
       const mapClickButton = screen.getByTestId("mock-map-click");
       await act(async () => {
@@ -355,7 +377,7 @@ describe("DiaryPage (旅の日記画面)", () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByText("新しい日記を作成")).toBeInTheDocument();
+        expect(screen.getByLabelText(/タイトル/)).toBeInTheDocument();
       });
 
       // キャンセルボタンをクリック
@@ -366,7 +388,7 @@ describe("DiaryPage (旅の日記画面)", () => {
 
       // フォームが閉じる
       await waitFor(() => {
-        expect(screen.queryByText("新しい日記を作成")).not.toBeInTheDocument();
+        expect(screen.queryByLabelText(/タイトル/)).not.toBeInTheDocument();
       });
     });
   });

--- a/frontend/__tests__/home.page.test.tsx
+++ b/frontend/__tests__/home.page.test.tsx
@@ -8,14 +8,15 @@ describe("Home (トップページ)", () => {
     // タイトル
     expect(screen.getByText("Roamory")).toBeInTheDocument();
     // キャッチコピー
-    expect(screen.getByText(/旅する、記憶を残す/)).toBeInTheDocument();
+    expect(screen.getByText(/旅の記憶を/)).toBeInTheDocument();
+    expect(screen.getByText(/永遠に残す/)).toBeInTheDocument();
     // 特徴カード
-    expect(screen.getByText("AI旅行プラン生成")).toBeInTheDocument();
-    expect(screen.getByText("地図×日記")).toBeInTheDocument();
-    expect(screen.getByText("訪問国の可視化")).toBeInTheDocument();
+    expect(screen.getByText("AI旅行プランナー")).toBeInTheDocument();
+    expect(screen.getByText("インタラクティブマップ")).toBeInTheDocument();
+    expect(screen.getByText("スマート写真解析")).toBeInTheDocument();
     // 行動喚起ボタン
     expect(
-      screen.getByRole("link", { name: "今すぐはじめる" })
+      screen.getByRole("link", { name: /無料で始める/ })
     ).toBeInTheDocument();
   });
 });

--- a/frontend/__tests__/password-validation.test.tsx
+++ b/frontend/__tests__/password-validation.test.tsx
@@ -1,0 +1,257 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import RegisterPage from "../src/app/register/page";
+import { Suspense } from "react";
+import ResetPasswordPage from "../src/app/reset-password/page";
+
+// モック
+jest.mock("@/components/Header", () => () => <div data-testid="mock-header" />);
+jest.mock("@/lib/api", () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+}));
+jest.mock("react-icons/fa", () => ({
+  FaUserPlus: () => <div data-testid="icon-user-plus" />,
+  FaCheckCircle: () => <div data-testid="icon-check-circle" />,
+  FaEnvelope: () => <div data-testid="icon-envelope" />,
+  FaPaperPlane: () => <div data-testid="icon-paper-plane" />,
+  FaEye: () => <div data-testid="icon-eye" />,
+  FaEyeSlash: () => <div data-testid="icon-eye-slash" />,
+  FaKey: () => <div data-testid="icon-key" />,
+}));
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+  }),
+  useSearchParams: () => ({
+    get: (key: string) => {
+      if (key === "token") return "test-token";
+      if (key === "email") return "test@example.com";
+      return null;
+    },
+  }),
+}));
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const mockRegister = jest.fn();
+const mockClearRegistrationState = jest.fn();
+const mockClearResendState = jest.fn();
+const mockResendVerificationEmail = jest.fn();
+const mockFetchMe = jest.fn();
+
+jest.mock("@/store/auth", () => ({
+  useAuthStore: jest.fn((selector) => {
+    if (selector) {
+      return mockFetchMe;
+    }
+    return {
+      loading: false,
+      isAuthenticated: false,
+      error: null,
+      registrationSuccess: false,
+      registrationMessage: null,
+      registrationEmail: null,
+      resendLoading: false,
+      resendSuccess: null,
+      resendError: null,
+      emailUnverified: false,
+      unverifiedEmail: null,
+      register: mockRegister,
+      clearRegistrationState: mockClearRegistrationState,
+      clearResendState: mockClearResendState,
+      resendVerificationEmail: mockResendVerificationEmail,
+      clearEmailUnverifiedState: jest.fn(),
+      isAuthLoading: false,
+      setState: jest.fn(),
+    };
+  }),
+}));
+
+describe("パスワードバリデーション - ユーザー登録", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("8文字未満のパスワードでエラー表示", async () => {
+    render(<RegisterPage />);
+
+    const passwordInput = screen.getByPlaceholderText("英字と数字を含む8～20文字");
+    await userEvent.type(passwordInput, "Pass1");
+    await userEvent.tab(); // フォーカスを外す
+
+    await waitFor(() => {
+      expect(screen.getByText("パスワードは8文字以上で入力してください。")).toBeInTheDocument();
+    });
+  });
+
+  it("20文字を超えるパスワードはmaxLength属性で制限される", async () => {
+    render(<RegisterPage />);
+
+    const passwordInput = screen.getByPlaceholderText("英字と数字を含む8～20文字") as HTMLInputElement;
+
+    // maxLength属性が設定されていることを確認
+    expect(passwordInput.maxLength).toBe(20);
+
+    // 20文字まで入力
+    await userEvent.type(passwordInput, "Password123456789012");
+    expect(passwordInput.value).toBe("Password123456789012");
+    expect(passwordInput.value.length).toBe(20);
+
+    // 21文字目は入力されない
+    await userEvent.type(passwordInput, "3");
+    expect(passwordInput.value).toBe("Password123456789012"); // 20文字のまま
+    expect(passwordInput.value.length).toBe(20);
+  });
+
+  it("数字のみのパスワードでエラー表示", async () => {
+    render(<RegisterPage />);
+
+    const passwordInput = screen.getByPlaceholderText("英字と数字を含む8～20文字");
+    await userEvent.type(passwordInput, "12345678");
+    await userEvent.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText("パスワードは英字と数字の両方を含む必要があります。")).toBeInTheDocument();
+    });
+  });
+
+  it("英字のみのパスワードでエラー表示", async () => {
+    render(<RegisterPage />);
+
+    const passwordInput = screen.getByPlaceholderText("英字と数字を含む8～20文字");
+    await userEvent.type(passwordInput, "Password");
+    await userEvent.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText("パスワードは英字と数字の両方を含む必要があります。")).toBeInTheDocument();
+    });
+  });
+
+  it("正しい形式のパスワードではエラーが表示されない", async () => {
+    render(<RegisterPage />);
+
+    const passwordInput = screen.getByPlaceholderText("英字と数字を含む8～20文字");
+    await userEvent.type(passwordInput, "Password123");
+    await userEvent.tab();
+
+    await waitFor(() => {
+      expect(screen.queryByText("パスワードは8文字以上で入力してください。")).not.toBeInTheDocument();
+      expect(screen.queryByText("パスワードは20文字以内で入力してください。")).not.toBeInTheDocument();
+      expect(screen.queryByText("パスワードは英字と数字の両方を含む必要があります。")).not.toBeInTheDocument();
+    });
+  });
+
+  it("パスワード要件の説明が表示される", () => {
+    render(<RegisterPage />);
+    expect(screen.getByText("※ 英字と数字を含む8～20文字で入力してください")).toBeInTheDocument();
+  });
+});
+
+describe("パスワードバリデーション - パスワードリセット", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("8文字未満のパスワードでエラー表示", async () => {
+    render(
+      <Suspense fallback={<div>Loading...</div>}>
+        <ResetPasswordPage />
+      </Suspense>
+    );
+
+    const passwordInput = screen.getByPlaceholderText("英字と数字を含む8～20文字");
+    await userEvent.type(passwordInput, "Pass1");
+
+    await waitFor(() => {
+      expect(screen.getByText("パスワードは8文字以上で入力してください。")).toBeInTheDocument();
+    });
+  });
+
+  it("20文字を超えるパスワードはmaxLength属性で制限される", async () => {
+    render(
+      <Suspense fallback={<div>Loading...</div>}>
+        <ResetPasswordPage />
+      </Suspense>
+    );
+
+    const passwordInput = screen.getByPlaceholderText("英字と数字を含む8～20文字") as HTMLInputElement;
+
+    // maxLength属性が設定されていることを確認
+    expect(passwordInput.maxLength).toBe(20);
+
+    // 20文字まで入力
+    await userEvent.type(passwordInput, "Password123456789012");
+    expect(passwordInput.value).toBe("Password123456789012");
+    expect(passwordInput.value.length).toBe(20);
+
+    // 21文字目は入力されない
+    await userEvent.type(passwordInput, "3");
+    expect(passwordInput.value).toBe("Password123456789012"); // 20文字のまま
+    expect(passwordInput.value.length).toBe(20);
+  });
+
+  it("数字のみのパスワードでエラー表示", async () => {
+    render(
+      <Suspense fallback={<div>Loading...</div>}>
+        <ResetPasswordPage />
+      </Suspense>
+    );
+
+    const passwordInput = screen.getByPlaceholderText("英字と数字を含む8～20文字");
+    await userEvent.type(passwordInput, "12345678");
+
+    await waitFor(() => {
+      expect(screen.getByText("パスワードは英字と数字の両方を含む必要があります。")).toBeInTheDocument();
+    });
+  });
+
+  it("英字のみのパスワードでエラー表示", async () => {
+    render(
+      <Suspense fallback={<div>Loading...</div>}>
+        <ResetPasswordPage />
+      </Suspense>
+    );
+
+    const passwordInput = screen.getByPlaceholderText("英字と数字を含む8～20文字");
+    await userEvent.type(passwordInput, "Password");
+
+    await waitFor(() => {
+      expect(screen.getByText("パスワードは英字と数字の両方を含む必要があります。")).toBeInTheDocument();
+    });
+  });
+
+  it("正しい形式のパスワードではエラーが表示されない", async () => {
+    render(
+      <Suspense fallback={<div>Loading...</div>}>
+        <ResetPasswordPage />
+      </Suspense>
+    );
+
+    const passwordInput = screen.getByPlaceholderText("英字と数字を含む8～20文字");
+    await userEvent.type(passwordInput, "Password123");
+
+    await waitFor(() => {
+      expect(screen.queryByText("パスワードは8文字以上で入力してください。")).not.toBeInTheDocument();
+      expect(screen.queryByText("パスワードは20文字以内で入力してください。")).not.toBeInTheDocument();
+      expect(screen.queryByText("パスワードは英字と数字の両方を含む必要があります。")).not.toBeInTheDocument();
+    });
+  });
+
+  it("パスワード要件の説明が表示される", () => {
+    render(
+      <Suspense fallback={<div>Loading...</div>}>
+        <ResetPasswordPage />
+      </Suspense>
+    );
+    expect(screen.getByText("※ 英字と数字を含む8～20文字で入力してください")).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/register.page.test.tsx
+++ b/frontend/__tests__/register.page.test.tsx
@@ -71,7 +71,7 @@ describe("RegisterPage (新規登録画面)", () => {
     ).toBeInTheDocument();
     expect(screen.getByPlaceholderText("ユーザー名")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("メールアドレス")).toBeInTheDocument();
-    expect(screen.getByPlaceholderText("パスワード")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("英字と数字を含む8～20文字")).toBeInTheDocument();
     expect(
       screen.getByPlaceholderText("パスワード（確認）")
     ).toBeInTheDocument();
@@ -126,7 +126,6 @@ describe("RegisterPage (新規登録画面)", () => {
     expect(screen.getByText("認証メール送信先：")).toBeInTheDocument();
     expect(screen.getByText("test@example.com")).toBeInTheDocument();
     expect(screen.getByText("認証メールを再送信")).toBeInTheDocument();
-    expect(screen.getByText("別のアカウントを作成")).toBeInTheDocument();
 
     // フォームが非表示になることを確認
     expect(
@@ -134,40 +133,4 @@ describe("RegisterPage (新規登録画面)", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("別のアカウントを作成ボタンで登録状態がクリアされる", () => {
-    // 成功状態のためのモック更新
-    const { useAuthStore } = require("@/store/auth");
-    useAuthStore.mockImplementation((selector: any) => {
-      if (selector) {
-        return mockFetchMe;
-      }
-      return {
-        loading: false,
-        isAuthenticated: false,
-        error: null,
-        registrationSuccess: true,
-        registrationMessage: "アカウントが作成されました。",
-        registrationEmail: "test@example.com",
-        resendLoading: false,
-        resendSuccess: null,
-        resendError: null,
-        emailUnverified: false,
-        unverifiedEmail: null,
-        register: mockRegister,
-        clearRegistrationState: mockClearRegistrationState,
-        clearResendState: mockClearResendState,
-        resendVerificationEmail: mockResendVerificationEmail,
-        clearEmailUnverifiedState: jest.fn(),
-        isAuthLoading: false,
-      };
-    });
-
-    render(<RegisterPage />);
-
-    const tryAgainButton = screen.getByText("別のアカウントを作成");
-    fireEvent.click(tryAgainButton);
-
-    expect(mockClearRegistrationState).toHaveBeenCalled();
-    expect(mockClearResendState).toHaveBeenCalled();
-  });
 });

--- a/frontend/__tests__/reset-password.page.test.tsx
+++ b/frontend/__tests__/reset-password.page.test.tsx
@@ -63,7 +63,7 @@ describe("ResetPasswordPage (パスワードリセット画面)", () => {
       ).toBeInTheDocument();
       
       expect(
-        screen.getByPlaceholderText("8文字以上のパスワード")
+        screen.getByPlaceholderText("英字と数字を含む8～20文字")
       ).toBeInTheDocument();
       
       expect(
@@ -87,7 +87,7 @@ describe("ResetPasswordPage (パスワードリセット画面)", () => {
 
     it("パスワードと確認パスワードを入力するとボタンがenabledになる", async () => {
       render(<ResetPasswordPage />);
-      const passwordInput = screen.getByPlaceholderText("8文字以上のパスワード");
+      const passwordInput = screen.getByPlaceholderText("英字と数字を含む8～20文字");
       const confirmInput = screen.getByPlaceholderText("パスワードを再入力");
       const button = screen.getByRole("button", { name: "パスワードをリセット" });
       
@@ -99,7 +99,7 @@ describe("ResetPasswordPage (パスワードリセット画面)", () => {
 
     it("パスワード表示/非表示の切り替えができる", async () => {
       render(<ResetPasswordPage />);
-      const passwordInput = screen.getByPlaceholderText("8文字以上のパスワード") as HTMLInputElement;
+      const passwordInput = screen.getByPlaceholderText("英字と数字を含む8～20文字") as HTMLInputElement;
       const confirmInput = screen.getByPlaceholderText("パスワードを再入力") as HTMLInputElement;
       
       // 初期状態はpassword type
@@ -121,7 +121,7 @@ describe("ResetPasswordPage (パスワードリセット画面)", () => {
 
     it("パスワードが一致しない場合エラーメッセージが表示される", async () => {
       render(<ResetPasswordPage />);
-      const passwordInput = screen.getByPlaceholderText("8文字以上のパスワード");
+      const passwordInput = screen.getByPlaceholderText("英字と数字を含む8～20文字");
       const confirmInput = screen.getByPlaceholderText("パスワードを再入力");
       const button = screen.getByRole("button", { name: "パスワードをリセット" });
       
@@ -134,7 +134,7 @@ describe("ResetPasswordPage (パスワードリセット画面)", () => {
 
     it("パスワードが8文字未満の場合エラーメッセージが表示される", async () => {
       render(<ResetPasswordPage />);
-      const passwordInput = screen.getByPlaceholderText("8文字以上のパスワード");
+      const passwordInput = screen.getByPlaceholderText("英字と数字を含む8～20文字");
       const confirmInput = screen.getByPlaceholderText("パスワードを再入力");
       const button = screen.getByRole("button", { name: "パスワードをリセット" });
       
@@ -142,9 +142,9 @@ describe("ResetPasswordPage (パスワードリセット画面)", () => {
       await userEvent.type(confirmInput, "short");
       await userEvent.click(button);
       
-      expect(
-        screen.getByText("パスワードは8文字以上で入力してください。")
-      ).toBeInTheDocument();
+      // 複数のエラーメッセージが表示される可能性があるので、少なくとも1つあることを確認
+      const errors = screen.getAllByText("パスワードは8文字以上で入力してください。");
+      expect(errors.length).toBeGreaterThanOrEqual(1);
     });
 
     it.skip("リセット成功時に成功画面が表示され、3秒後にログイン画面へ遷移する", async () => {
@@ -162,7 +162,7 @@ describe("ResetPasswordPage (パスワードリセット画面)", () => {
         expect(screen.getByRole("heading", { name: "新しいパスワードを設定" })).toBeInTheDocument();
       }, { timeout: 5000 });
 
-      const passwordInput = screen.getByPlaceholderText("8文字以上のパスワード");
+      const passwordInput = screen.getByPlaceholderText("英字と数字を含む8～20文字");
       const confirmInput = screen.getByPlaceholderText("パスワードを再入力");
       const button = screen.getByRole("button", { name: "パスワードをリセット" });
 
@@ -221,7 +221,7 @@ describe("ResetPasswordPage (パスワードリセット画面)", () => {
         expect(screen.getByRole("heading", { name: "新しいパスワードを設定" })).toBeInTheDocument();
       }, { timeout: 5000 });
 
-      const passwordInput = screen.getByPlaceholderText("8文字以上のパスワード");
+      const passwordInput = screen.getByPlaceholderText("英字と数字を含む8～20文字");
       const confirmInput = screen.getByPlaceholderText("パスワードを再入力");
       const button = screen.getByRole("button", { name: "パスワードをリセット" });
 
@@ -268,7 +268,7 @@ describe("ResetPasswordPage (パスワードリセット画面)", () => {
         expect(screen.getByRole("heading", { name: "新しいパスワードを設定" })).toBeInTheDocument();
       }, { timeout: 5000 });
 
-      const passwordInput = screen.getByPlaceholderText("8文字以上のパスワード");
+      const passwordInput = screen.getByPlaceholderText("英字と数字を含む8～20文字");
       const confirmInput = screen.getByPlaceholderText("パスワードを再入力");
       const button = screen.getByRole("button", { name: "パスワードをリセット" });
 
@@ -296,7 +296,7 @@ describe("ResetPasswordPage (パスワードリセット画面)", () => {
         expect(screen.getByRole("heading", { name: "新しいパスワードを設定" })).toBeInTheDocument();
       }, { timeout: 5000 });
 
-      const passwordInput = screen.getByPlaceholderText("8文字以上のパスワード");
+      const passwordInput = screen.getByPlaceholderText("英字と数字を含む8～20文字");
       const confirmInput = screen.getByPlaceholderText("パスワードを再入力");
       const button = screen.getByRole("button", { name: "パスワードをリセット" });
 

--- a/frontend/src/app/diary/detail/page.tsx
+++ b/frontend/src/app/diary/detail/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, Suspense } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
 import Header from "@/components/Header";
@@ -25,7 +25,7 @@ const DiaryMap = dynamic(() => import("@/components/DiaryMap"), {
   ),
 });
 
-export default function DiaryDetailPage() {
+function DiaryDetailContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const id = searchParams.get("id");
@@ -328,5 +328,13 @@ export default function DiaryDetailPage() {
         </div>
       </div>
     </>
+  );
+}
+
+export default function DiaryDetailPage() {
+  return (
+    <Suspense fallback={<AuthLoadingModal />}>
+      <DiaryDetailContent />
+    </Suspense>
   );
 }

--- a/frontend/src/app/forgot-password/page.tsx
+++ b/frontend/src/app/forgot-password/page.tsx
@@ -23,16 +23,17 @@ export default function ForgotPasswordPage() {
       setSentEmail(email);
       setSuccess(true);
       setEmail("");
-    } catch (err: any) {
-      if (err.response?.status === 429) {
+    } catch (err: unknown) {
+      const error = err as { response?: { status?: number; data?: { message?: string } } };
+      if (error.response?.status === 429) {
         // 429エラーでもサーバーからの具体的なメッセージを優先
-        if (err.response?.data?.message) {
-          setError(err.response.data.message);
+        if (error.response?.data?.message) {
+          setError(error.response.data.message);
         } else {
           setError("パスワードリセットメールの再送信は5分間隔で行えます。しばらくお待ちください。");
         }
-      } else if (err.response?.data?.message) {
-        setError(err.response.data.message);
+      } else if (error.response?.data?.message) {
+        setError(error.response.data.message);
       } else {
         setError("エラーが発生しました。もう一度お試しください。");
       }

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -73,16 +73,36 @@ export default function RegisterPage() {
     };
   }, [clearRegistrationState]);
 
+  const validatePassword = (pwd: string): string | null => {
+    if (pwd.length < 8) return "パスワードは8文字以上で入力してください。";
+    if (pwd.length > 20) return "パスワードは20文字以内で入力してください。";
+    if (!/[a-zA-Z]/.test(pwd) || !/\d/.test(pwd)) {
+      return "パスワードは英字と数字の両方を含む必要があります。";
+    }
+    return null;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    // フロントエンドバリデーションチェック（submit時のみ）
+    const passwordError = validatePassword(password);
+    if (passwordError || password !== passwordConfirmation) {
+      // エラーは各入力欄の下に既に表示されるので、
+      // touchedフラグを立てて表示させる
+      setTouched({
+        name: true,
+        email: true,
+        password: true,
+        passwordConfirmation: true,
+      });
+      return;
+    }
+
     setRegisterAttempted(true);
     await register(name, email, password, passwordConfirmation);
   };
 
-  const handleTryAgain = () => {
-    clearRegistrationState();
-    clearResendState();
-  };
 
   const handleResendEmail = async () => {
     clearResendState();
@@ -146,11 +166,11 @@ export default function RegisterPage() {
             )}
 
             {/* ボタンエリア */}
-            <div className="flex gap-3 pt-4 border-t border-green-200">
+            <div className="pt-4 border-t border-green-200">
               <button
                 onClick={handleResendEmail}
                 disabled={resendLoading}
-                className="flex-1 inline-flex items-center justify-center gap-2 bg-blue-500 hover:bg-blue-600 disabled:bg-blue-300 text-white py-2 px-4 rounded-lg font-medium transition-colors"
+                className="w-full inline-flex items-center justify-center gap-2 bg-blue-500 hover:bg-blue-600 disabled:bg-blue-300 text-white py-2 px-4 rounded-lg font-medium transition-colors"
               >
                 {resendLoading ? (
                   <>
@@ -163,12 +183,6 @@ export default function RegisterPage() {
                     認証メールを再送信
                   </>
                 )}
-              </button>
-              <button
-                onClick={handleTryAgain}
-                className="flex-1 bg-gray-100 hover:bg-gray-200 text-gray-700 py-2 px-4 rounded-lg font-medium transition-colors"
-              >
-                別のアカウントを作成
               </button>
             </div>
           </div>
@@ -243,7 +257,7 @@ export default function RegisterPage() {
                   <input
                     id="password"
                     type={showPassword ? "text" : "password"}
-                    placeholder="パスワード"
+                    placeholder="英字と数字を含む8～20文字"
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                     onBlur={() =>
@@ -251,6 +265,8 @@ export default function RegisterPage() {
                     }
                     className="w-full border border-gray-300 p-2 rounded-lg focus:ring-2 focus:ring-blue-300 focus:border-blue-400 transition pr-10 h-10"
                     required
+                    minLength={8}
+                    maxLength={20}
                   />
                   <button
                     type="button"
@@ -269,6 +285,14 @@ export default function RegisterPage() {
                     パスワードは必須です
                   </p>
                 )}
+                {touched.password && password && validatePassword(password) && (
+                  <p className="text-red-500 text-sm mt-1">
+                    {validatePassword(password)}
+                  </p>
+                )}
+                <p className="text-gray-500 text-xs mt-1">
+                  ※ 英字と数字を含む8～20文字で入力してください
+                </p>
               </div>
               <div>
                 <label
@@ -312,8 +336,17 @@ export default function RegisterPage() {
                     パスワード（確認）は必須です
                   </p>
                 )}
+                {touched.passwordConfirmation && passwordConfirmation && password !== passwordConfirmation && (
+                  <p className="text-red-500 text-sm mt-1">
+                    パスワードが一致しません
+                  </p>
+                )}
               </div>
-              {error && <div className="text-red-500 text-sm">{error}</div>}
+              {error && (
+                <div className="bg-red-50 border border-red-200 rounded-lg p-3">
+                  <p className="text-red-700 text-sm">{error}</p>
+                </div>
+              )}
               <button
                 type="submit"
                 className="w-full bg-gradient-to-r from-blue-500 to-sky-400 hover:from-blue-600 hover:to-sky-500 text-white py-2 rounded-lg shadow-lg font-bold text-lg transition-all duration-200 disabled:opacity-50"

--- a/frontend/src/app/reset-password/page.tsx
+++ b/frontend/src/app/reset-password/page.tsx
@@ -26,16 +26,27 @@ function ResetPasswordForm() {
     }
   }, [token, email]);
 
+  const validatePassword = (pwd: string): string | null => {
+    if (pwd.length < 8) return "パスワードは8文字以上で入力してください。";
+    if (pwd.length > 20) return "パスワードは20文字以内で入力してください。";
+    if (!/[a-zA-Z]/.test(pwd) || !/\d/.test(pwd)) {
+      return "パスワードは英字と数字の両方を含む必要があります。";
+    }
+    return null;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
-    if (password !== passwordConfirmation) {
-      setError("パスワードが一致しません。");
+
+    // パスワードバリデーション
+    const passwordError = validatePassword(password);
+    if (passwordError) {
+      setError(passwordError);
       return;
     }
 
-    if (password.length < 8) {
-      setError("パスワードは8文字以上で入力してください。");
+    if (password !== passwordConfirmation) {
+      setError("パスワードが一致しません。");
       return;
     }
 
@@ -53,9 +64,10 @@ function ResetPasswordForm() {
       setTimeout(() => {
         router.push("/login");
       }, 3000);
-    } catch (err: any) {
-      if (err.response?.data?.message) {
-        setError(err.response.data.message);
+    } catch (err: unknown) {
+      const error = err as { response?: { data?: { message?: string } } };
+      if (error.response?.data?.message) {
+        setError(error.response.data.message);
       } else {
         setError("エラーが発生しました。もう一度お試しください。");
       }
@@ -142,13 +154,14 @@ function ResetPasswordForm() {
                 <input
                   id="password"
                   type={showPassword ? "text" : "password"}
-                  placeholder="8文字以上のパスワード"
+                  placeholder="英字と数字を含む8～20文字"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   className="w-full border border-gray-300 p-2 rounded-lg focus:ring-2 focus:ring-blue-300 focus:border-blue-400 transition pr-10"
                   required
                   disabled={loading}
                   minLength={8}
+                  maxLength={20}
                 />
                 <button
                   type="button"
@@ -160,6 +173,14 @@ function ResetPasswordForm() {
                   {showPassword ? <FaEyeSlash /> : <FaEye />}
                 </button>
               </div>
+              {password && validatePassword(password) && (
+                <p className="text-red-500 text-sm mt-1">
+                  {validatePassword(password)}
+                </p>
+              )}
+              <p className="text-gray-500 text-xs mt-1">
+                ※ 英字と数字を含む8～20文字で入力してください
+              </p>
             </div>
 
             <div>
@@ -180,6 +201,7 @@ function ResetPasswordForm() {
                   required
                   disabled={loading}
                   minLength={8}
+                  maxLength={20}
                 />
                 <button
                   type="button"
@@ -191,6 +213,11 @@ function ResetPasswordForm() {
                   {showPasswordConfirmation ? <FaEyeSlash /> : <FaEye />}
                 </button>
               </div>
+              {passwordConfirmation && password !== passwordConfirmation && (
+                <p className="text-red-500 text-sm mt-1">
+                  パスワードが一致しません
+                </p>
+              )}
             </div>
 
             {error && (

--- a/frontend/src/components/DiaryMap.tsx
+++ b/frontend/src/components/DiaryMap.tsx
@@ -31,11 +31,30 @@ export default function DiaryMap({
   const onDiaryClickRef = useRef(onDiaryClick);
   const markersRef = useRef<L.Marker[]>([]);
   const clickedMarkerRef = useRef<L.Marker | null>(null);
-  const highlightLayersRef = useRef<L.Rectangle[]>([]);
+  const highlightLayersRef = useRef<L.GeoJSON[]>([]);
   const [showHelp, setShowHelp] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
   const [visitedCountryCodes, setVisitedCountryCodes] = useState<string[]>([]);
-  const [countryGeoJson, setCountryGeoJson] = useState<any>(null);
+  const [countryGeoJson, setCountryGeoJson] = useState<{
+    type: "FeatureCollection";
+    features: Array<{
+      type: "Feature";
+      properties: {
+        ISO_A2?: string;
+        ISO_A2_EH?: string;
+        WB_A2?: string;
+        POSTAL?: string;
+        NAME?: string;
+        NAME_JA?: string;
+        SUBREGION?: string;
+        CONTINENT?: string;
+      };
+      geometry: {
+        type: "Polygon" | "MultiPolygon";
+        coordinates: number[][][] | number[][][][];
+      };
+    }>;
+  } | null>(null);
   const [isMapInitialized, setIsMapInitialized] = useState(false);
 
   // refの値を更新
@@ -215,7 +234,7 @@ export default function DiaryMap({
     visitedCountryCodes.forEach((countryCode) => {
       // Natural Earth FeatureCollectionからの検索
       if (countryGeoJson?.features) {
-        const countryFeature = countryGeoJson.features.find((feature: any) => {
+        const countryFeature = countryGeoJson.features.find((feature) => {
           const props = feature.properties;
           // 複数のフィールドをチェック（Natural Earthデータの不整合に対応）
           return (
@@ -252,7 +271,7 @@ export default function DiaryMap({
               </div>
             `);
 
-          highlightLayersRef.current.push(geoJsonLayer as any);
+          highlightLayersRef.current.push(geoJsonLayer);
         }
       }
     });


### PR DESCRIPTION
ユーザー登録時、パスワードリセット時のパスワード強度の強化（文字と数字を含む）
フロントエンド テストのエラー解消
ユーザー登録画面の別アカウント作成遷移ボタンの削除
ビルド時のリントエラーの解消